### PR TITLE
fix(Home): Fix sorting order for posts

### DIFF
--- a/client/src/pages/home.js
+++ b/client/src/pages/home.js
@@ -62,7 +62,7 @@ const Home = () => {
             const entry = entries[0]
             if (entry.isIntersecting) {
                 if (data) {
-                    setSkip(data.feedForYou.cursorId)
+                    setSkip(posts.length)
                 }
             }
         })

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -473,7 +473,7 @@ const Query = objectType({
       },
       resolve: async (_, args, context) => {
         const posts = await context.prisma.post.findMany({
-          take: 2,
+          take: 4,
           skip: args.skip,
           include: {
             author: {
@@ -489,7 +489,7 @@ const Query = objectType({
               },
             },
           },
-          orderBy: [{ id: 'asc' }],
+          orderBy: [{ id: 'desc' }],
         })
         return {
           posts: posts,


### PR DESCRIPTION
This is the fix for [Issue#21](https://github.com/leanhduy/threads-clone/issues/21)

Updated schema.js to sort posts by id in descending order. Modified the React Home component to handle pagination correctly, skipping the correct number of posts based on the current page.

Closes P1-68